### PR TITLE
Adapt gemspec to opensuse requirements

### DIFF
--- a/configgin.gemspec
+++ b/configgin.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
 
   spec.add_dependency 'bosh-template', '~> 1.3262.24.0'
   spec.add_dependency 'rainbow', '~>2.0', '!=2.2.1'
-  spec.add_dependency 'deep_merge', '~> 1.0.1'
+  spec.add_dependency 'deep_merge', '~> 1.1'
   spec.add_dependency 'mustache', '~> 1.0'
 end

--- a/configgin.gemspec
+++ b/configgin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  spec.add_dependency 'bosh-template', '~> 1.3262.24.0'
+  spec.add_dependency 'bosh-template', '~> 1.3262', '>= 1.3262.24.0'
   spec.add_dependency 'rainbow', '~>2.0', '!=2.2.1'
   spec.add_dependency 'deep_merge', '~> 1.1'
   spec.add_dependency 'mustache', '~> 1.0'

--- a/lib/configgin/version.rb
+++ b/lib/configgin/version.rb
@@ -1,5 +1,5 @@
 module Configgin
 
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 
 end


### PR DESCRIPTION
OpenSUSE has a newer deep_merge gem and an older bundler by default.