### PR TITLE
Implement support for BOSH links

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,9 +9,12 @@
 Metrics/AbcSize:
   Max: 26
 
+Metrics/BlockLength:
+  Enabled: false
+
 # Offense count: 2
 Metrics/CyclomaticComplexity:
-  Max: 10
+  Enabled: false
 
 # Offense count: 20
 # Configuration parameters: AllowURI, URISchemes.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,54 @@
 PATH
   remote: .
   specs:
-    configgin (0.1.0)
-      bosh-template (~> 1.3262.24.0)
-      deep_merge (~> 1.0.1)
+    configgin (0.12.1)
+      bosh-template (~> 2.0)
+      deep_merge (~> 1.1)
+      kubeclient (~> 2.0)
       mustache (~> 1.0)
       rainbow (~> 2.0, != 2.2.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     ast (2.3.0)
-    bosh-template (1.3262.24.0)
+    bosh-template (2.0.0)
       semi_semantic (~> 1.2.0)
-    deep_merge (1.0.1)
+    deep_merge (1.1.1)
     diff-lcs (1.3)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    http (0.9.8)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (1.0.3)
+    http_parser.rb (0.6.0)
+    kubeclient (2.4.0)
+      http (= 0.9.8)
+      recursive-open-struct (= 1.0.0)
+      rest-client
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mustache (1.0.5)
+    netrc (0.11.0)
     parser (2.4.0.0)
       ast (~> 2.2)
     powerpack (0.1.1)
+    public_suffix (3.0.0)
     rainbow (2.1.0)
     rake (10.4.2)
+    recursive-open-struct (1.0.0)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -42,13 +70,16 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
     semi_semantic (1.2.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
     unicode-display_width (1.2.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.14)
+  bundler (~> 1.10)
   configgin!
   rake (~> 10.0)
   rspec

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/env make
 
-GIT_ROOT:=$(shell git rev-parse --show-toplevel)
+GIT_ROOT := $(shell git rev-parse --show-toplevel)
 
 .PHONY: lint test dist
 

--- a/bin/configgin
+++ b/bin/configgin
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'json'
 require_relative "../lib/configgin"
 
 options = {}
@@ -14,23 +15,52 @@ rescue ArgMissingError => e
   exit(1)
 end
 
-jobs = JSON.load(File.read(options[:jobs]))
+job_configs = JSON.parse(File.read(options[:jobs]))
 templates = YAML.load_file(options[:env2conf])
 
-jobs.each do |job, job_config|
-  base_config = JSON.load(File.read(job_config['base']))
+# SVC_ACC_PATH is the location of the service account secrets
+SVC_ACC_PATH = '/var/run/secrets/kubernetes.io/serviceaccount'.freeze
 
-  job_config['files'].each do |infile, outfile|
-    begin
-      bosh_spec = EnvironmentConfigTransmogrifier.transmogrify(base_config,
-                                                               templates,
-                                                               secrets: '/etc/secrets')
-    rescue NonHashValueOverride => e
-      STDERR.puts e.to_s
-      STDERR.puts "Error generating #{job}: #{outfile} from #{infile}"
-      exit 1
-    end
+kube_client = Kubeclient::Client.new(
+  URI::HTTPS.build(host: ENV['KUBERNETES_SERVICE_HOST'],
+                   port: ENV['KUBERNETES_SERVICE_PORT_HTTPS']),
+  'v1',
+  ssl_options: {
+    ca_file: "#{SVC_ACC_PATH}/ca.crt",
+    verify_ssl: OpenSSL::SSL::VERIFY_PEER
+  },
+  auth_options: {
+    bearer_token: File.read("#{SVC_ACC_PATH}/token")
+  }
+)
+kube_namespace = File.read("#{SVC_ACC_PATH}/namespace")
 
-    Generate.generate(bosh_spec, infile, outfile)
+jobs = {}
+job_configs.each do |job, job_config|
+  base_config = JSON.parse(File.read(job_config['base']))
+
+  begin
+    bosh_spec = EnvironmentConfigTransmogrifier.transmogrify(base_config,
+                                                             templates,
+                                                             secrets: '/etc/secrets')
+  rescue NonHashValueOverride => e
+    STDERR.puts e.to_s
+    STDERR.puts "Error generating #{job}: #{outfile} from #{infile}"
+    exit 1
+  end
+
+  jobs[job] = Job.new(bosh_spec, kube_namespace, kube_client)
+end
+
+exported_properties = Hash[jobs.map { |name, job| [name, job.exported_properties] }]
+kube_client.patch_pod(ENV['HOSTNAME'], {
+  metadata: { annotations: { :'skiff-exported-properties' => exported_properties.to_json } }
+}, kube_namespace)
+
+jobs.each do |job_name, job|
+  dns_encoder = KubeDNSEncoder.new(job.spec['links'])
+
+  job_configs[job_name]['files'].each do |infile, outfile|
+    job.generate(infile, outfile, dns_encoder)
   end
 end

--- a/bin/configgin
+++ b/bin/configgin
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'json'
-require_relative "../lib/configgin"
+require_relative '../lib/configgin'
 
 options = {}
 parser = Cli.make_option_parser(options)
@@ -53,9 +53,11 @@ job_configs.each do |job, job_config|
 end
 
 exported_properties = Hash[jobs.map { |name, job| [name, job.exported_properties] }]
-kube_client.patch_pod(ENV['HOSTNAME'], {
-  metadata: { annotations: { :'skiff-exported-properties' => exported_properties.to_json } }
-}, kube_namespace)
+kube_client.patch_pod(
+  ENV['HOSTNAME'],
+  { metadata: { annotations: { :'skiff-exported-properties' => exported_properties.to_json } } },
+  kube_namespace
+)
 
 jobs.each do |job_name, job|
   dns_encoder = KubeDNSEncoder.new(job.spec['links'])

--- a/configgin.gemspec
+++ b/configgin.gemspec
@@ -23,8 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  spec.add_dependency 'bosh-template', '~> 1.3262', '>= 1.3262.24.0'
+  spec.add_dependency 'bosh-template', '~> 2.0'
   spec.add_dependency 'rainbow', '~>2.0', '!=2.2.1'
   spec.add_dependency 'deep_merge', '~> 1.1'
   spec.add_dependency 'mustache', '~> 1.0'
+  spec.add_dependency 'kubeclient', '~>2.0'
 end

--- a/configgin.gemspec
+++ b/configgin.gemspec
@@ -5,23 +5,24 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'configgin/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "configgin"
+  spec.name          = 'configgin'
   spec.version       = Configgin::VERSION
-  spec.authors       = ["SUSE"]
+  spec.authors       = ['SUSE']
 
-  spec.summary       = "A simple cli app in Ruby to generate configurations using BOSH ERB templates and a BOSH spec."
-  spec.description   = "A simple cli app in Ruby to generate configurations using BOSH ERB templates and a BOSH spec, but also using configurations based on environment variables, processed using a set of templates."
-  spec.homepage      = "https://github.com/SUSE/configgin"
+  spec.summary       = 'A simple cli app in Ruby to generate configurations using BOSH ERB templates and a BOSH spec.'
+  spec.description   = 'A simple cli app in Ruby to generate configurations using BOSH ERB templates and a BOSH spec, but also using configurations based on environment variables, processed using a set of templates.'
+  spec.homepage      = 'https://github.com/SUSE/configgin'
+  spec.licenses      = ['Apache-2.0']
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "bin"
+  spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'rake', '~> 10.0'
 
   spec.add_dependency 'bosh-template', '~> 2.0'
   spec.add_dependency 'rainbow', '~>2.0', '!=2.2.1'

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -1,5 +1,4 @@
 require 'optparse'
-require 'generate'
 require 'exceptions'
 
 # Cli is a helper module for dealing with command line flags

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -1,5 +1,6 @@
 require 'optparse'
-require 'exceptions'
+require_relative 'exceptions'
+require_relative 'configgin/version'
 
 # Cli is a helper module for dealing with command line flags
 module Cli
@@ -7,7 +8,7 @@ module Cli
   #
   # @param options [Hash] The options to check
   def self.check_opts(options)
-    [:jobs, :env2conf].each do |key|
+    %i[jobs env2conf].each do |key|
       if options[key].nil? || options[key].empty?
         raise ArgMissingError, key.to_s
       end
@@ -31,6 +32,11 @@ module Cli
       opts.on('-e', '--env2conf file',
               'Environment to configuration templates YAML') do |e|
         options[:env2conf] = e
+      end
+
+      opts.on('--version', 'Print the configgin version') do
+        puts Configgin::VERSION
+        exit 0
       end
     end
   end

--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -1,4 +1,4 @@
-require 'cli'
-require 'environment_config_transmogrifier'
+require_relative 'cli'
 require_relative 'job'
+require_relative 'environment_config_transmogrifier'
 require_relative 'kube_link_generator'

--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -1,3 +1,4 @@
 require 'cli'
-require 'generate'
 require 'environment_config_transmogrifier'
+require_relative 'job'
+require_relative 'kube_link_generator'

--- a/lib/configgin/version.rb
+++ b/lib/configgin/version.rb
@@ -1,5 +1,3 @@
 module Configgin
-
-  VERSION = "0.12.1"
-
+  VERSION = '0.12.1'.freeze
 end

--- a/lib/environment_config_transmogrifier.rb
+++ b/lib/environment_config_transmogrifier.rb
@@ -46,7 +46,7 @@ module EnvironmentConfigTransmogrifier
       inject_value(base_config, key.split('.'), value, key)
     end
 
-    base_config['bootstrap'] = (base_config['index'] || 0) == 0
+    base_config['bootstrap'] = (base_config['index'] || 0).zero?
 
     base_config
   end
@@ -61,7 +61,7 @@ module EnvironmentConfigTransmogrifier
       # replace new lines with double new lines for proper new-line YAML parsing
       mustache_value = mustache_value.to_s.gsub("\n", "\n\n")
       @@memoize_mustache[value] ||= {}
-      @@memoize_mustache[value][input_hash] = YAML.load(mustache_value)
+      @@memoize_mustache[value][input_hash] = YAML.safe_load(mustache_value)
     rescue => e
       msg = mustacheMessageFromError(e)
       raise LoadYamlFromMustacheError, "Could not load config key '#{key}': #{msg}"

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -2,3 +2,4 @@ class ArgMissingError < StandardError; end
 class NonHashValueOverride < StandardError; end
 class NoDataProvided < StandardError; end
 class LoadYamlFromMustacheError < StandardError; end
+class LinkResolveError < StandardError; end

--- a/lib/job.rb
+++ b/lib/job.rb
@@ -1,6 +1,6 @@
 require 'bosh/template/renderer'
 require 'json'
-require_relative './kube_link_generator'
+require_relative 'kube_link_generator'
 
 # Job describes a single BOSH job
 class Job

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -1,0 +1,108 @@
+require 'kubeclient'
+require 'uri'
+require_relative 'exceptions'
+
+# KubeLinkSpecs provides the information required to generate BOSH links by
+# pretending to be a hash.
+class KubeLinkSpecs
+  # ANNOTATION_AZ is the Kube annotation for the (availability) zone
+  ANNOTATION_AZ = 'failure-domain.beta.kubernetes.io/zone'.freeze
+
+  def initialize(spec, namespace, kube_client)
+    @links = {}
+    @client = kube_client
+    @namespace = namespace
+    @spec = spec || {}
+  end
+
+  def this_name()
+    @spec['job']['name']
+  end
+
+  def pod_index(name)
+    index = name.rpartition('-').last
+    return index.to_i if /^\d+$/ =~ index
+    chars = 'bcdfghjklmnpqrstvwxz0123456789'
+    index.chars.map { |c| chars.index(c) }.reduce(0) { |v, c| v * chars.length + c }
+  end
+
+  def [](key)
+    return @links[key] if @links.key? key
+
+    # Resolve the role we're looking for
+    provider = @spec['consumes'][key]
+    unless provider
+      puts "No link provider found for #{key}"
+      @links[key] = nil
+      return @links[key]
+    end
+
+    @links[key] = {
+      'address' => "#{key}.#{ENV['KUBE_SERVICE_DOMAIN_SUFFIX']}",
+      'properties' => {},
+      'instance_group' => '',
+      'default_network' => '',
+      'deployment_name' => @namespace,
+      'domain' => ENV['KUBE_SERVICE_DOMAIN_SUFFIX'],
+      'root_domain' => ENV['KUBE_SERVICE_DOMAIN_SUFFIX']
+    }
+    if provider['role'] == this_name
+      STDERR.puts "Resolving link #{key} via self provider #{provider}"
+      pods = loop do
+        pods = @client.get_pods(namespace: @namespace, label_selector: "skiff-role-name=#{this_name}")
+        # Wait until we have at least one pod (the one this is running on), and they all have IP addresses
+        break pods unless pods.empty? || !pods.select { |pod| pod.status.podIP.nil? }.empty?
+        sleep 1
+      end
+      @links[key]['instances'] = pods.map do |pod|
+        unless pod.metadata.annotations['skiff-exported-properties']
+          until pod.metadata.annotations['skiff-exported-properties']
+            sleep 1
+            pod = @client.get_pod(pod.metadata.name, @namespace)
+          end
+        end
+        index = pod_index(pod.metadata.name)
+        properties = JSON.parse(pod.metadata.annotations['skiff-exported-properties'] || '{}')
+        {
+          'name' => pod.metadata.name,
+          'index' => index,
+          'id' => pod.metadata.name,
+          'az' => pod.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
+          'address' => pod.status.podIP,
+          'properties' => properties.fetch(provider['job'], {}),
+          'bootstrap' => index.zero?
+        }
+      end
+    else
+      STDERR.puts "Resolving link #{key} via service #{provider}"
+      # Getting pods for a different service; since we have kube services, we don't handle it in configgin
+      svc = @client.get_service(provider['role'], @namespace)
+      pods = loop do
+        pods = @client.get_pods(namespace: @namespace, label_selector: "skiff-role-name=#{provider['role']}")
+        pods.reject! { |pod| pod.status.podIP.nil? }
+        pods.select! { |pod| pods.first.metadata.annotations['skiff-exported-properties'] }
+        break pods unless pods.empty?
+        sleep 1
+      end
+      properties = JSON.parse(pods.first.metadata.annotations['skiff-exported-properties'] || '{}')
+      @links[key]['instances'] = [
+        'name' => svc.metadata.name,
+        'index' => 0,
+        'id' => svc.metadata.name,
+        'az' => pods.first.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
+        'address' => svc.spec.clusterIP,
+        'properties' => properties.fetch(provider['job'], {}),
+        'bootstrap' => true
+      ]
+    end
+    @links[key]['properties'] = @links[key]['instances'].first['properties']
+    @links[key]
+  end
+end
+
+# KubeDNSEncoder is a BOSH DNS encoder object. It is unclear at this point what it does.
+class KubeDNSEncoder
+  def initialize(link_specs)
+    @link_specs = link_specs
+  end
+end

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -75,7 +75,7 @@ class KubeLinkSpecs
     properties = JSON.parse(pod.metadata.annotations['skiff-exported-properties'])
     {
       'name' => svc.metadata.name,
-      'index' => 0,
+      'index' => 0, # Completely made up index; there is only ever one service
       'id' => svc.metadata.name,
       'az' => pod.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
       'address' => svc.spec.clusterIP,

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -15,7 +15,7 @@ class KubeLinkSpecs
     @spec = spec || {}
   end
 
-  def this_name()
+  def this_name
     @spec['job']['name']
   end
 
@@ -26,77 +26,82 @@ class KubeLinkSpecs
     index.chars.map { |c| chars.index(c) }.reduce(0) { |v, c| v * chars.length + c }
   end
 
+  def get_pods_for_role(role_name, wait_for_ip)
+    loop do
+      sleep 1
+      pods = @client.get_pods(namespace: @namespace, label_selector: "skiff-role-name=#{role_name}")
+      if wait_for_ip
+        # Wait until all pods have IP addresses and properties
+        next unless pods.all? { |pod| pod.status.podIP }
+        next unless pods.all? { |pod| pod.metadata.annotations['skiff-exported-properties'] }
+      else
+        # We just need one pod with exported properties
+        pods.select! { |pod| pod.status.podIP }
+        pods.select! { |pod| pod.metadata.annotations['skiff-exported-properties'] }
+      end
+      return pods unless pods.empty?
+    end
+  end
+
+  def get_pod_instance_info(pod, job)
+    index = pod_index(pod.metadata.name)
+    properties = JSON.parse(pod.metadata.annotations['skiff-exported-properties'])
+    {
+      'name' => pod.metadata.name,
+      'index' => index,
+      'id' => pod.metadata.name,
+      'az' => pod.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
+      'address' => pod.status.podIP,
+      'properties' => properties.fetch(job, {}),
+      'bootstrap' => index.zero?
+    }
+  end
+
+  def get_svc_instance_info(role_name, job)
+    svc = @client.get_service(role_name, @namespace)
+    pod = get_pods_for_role(role_name, false).first
+    properties = JSON.parse(pod.metadata.annotations['skiff-exported-properties'])
+    {
+      'name' => svc.metadata.name,
+      'index' => 0,
+      'id' => svc.metadata.name,
+      'az' => pod.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
+      'address' => svc.spec.clusterIP,
+      'properties' => properties.fetch(job, {}),
+      'bootstrap' => true
+    }
+  end
+
   def [](key)
     return @links[key] if @links.key? key
 
     # Resolve the role we're looking for
     provider = @spec['consumes'][key]
     unless provider
-      puts "No link provider found for #{key}"
+      STDERR.puts "No link provider found for #{key}"
       @links[key] = nil
       return @links[key]
     end
 
+    if provider['role'] == this_name
+      STDERR.puts "Resolving link #{key} via self provider #{provider}"
+      instances = get_pods_for_role(provider['role'], true).map {|p| get_pod_instance_info(p, provider['job'])}
+    else
+      # Getting pods for a different service; since we have kube services, we don't handle it in configgin
+      STDERR.puts "Resolving link #{key} via service #{provider}"
+      instances = [get_svc_instance_info(provider['role'], provider['job'])]
+    end
+
     @links[key] = {
       'address' => "#{key}.#{ENV['KUBE_SERVICE_DOMAIN_SUFFIX']}",
-      'properties' => {},
       'instance_group' => '',
       'default_network' => '',
       'deployment_name' => @namespace,
       'domain' => ENV['KUBE_SERVICE_DOMAIN_SUFFIX'],
-      'root_domain' => ENV['KUBE_SERVICE_DOMAIN_SUFFIX']
+      'root_domain' => ENV['KUBE_SERVICE_DOMAIN_SUFFIX'],
+      'instances' => instances,
+      'properties' => instances.first['properties']
     }
-    if provider['role'] == this_name
-      STDERR.puts "Resolving link #{key} via self provider #{provider}"
-      pods = loop do
-        pods = @client.get_pods(namespace: @namespace, label_selector: "skiff-role-name=#{this_name}")
-        # Wait until we have at least one pod (the one this is running on), and they all have IP addresses
-        break pods unless pods.empty? || !pods.select { |pod| pod.status.podIP.nil? }.empty?
-        sleep 1
-      end
-      @links[key]['instances'] = pods.map do |pod|
-        unless pod.metadata.annotations['skiff-exported-properties']
-          until pod.metadata.annotations['skiff-exported-properties']
-            sleep 1
-            pod = @client.get_pod(pod.metadata.name, @namespace)
-          end
-        end
-        index = pod_index(pod.metadata.name)
-        properties = JSON.parse(pod.metadata.annotations['skiff-exported-properties'] || '{}')
-        {
-          'name' => pod.metadata.name,
-          'index' => index,
-          'id' => pod.metadata.name,
-          'az' => pod.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
-          'address' => pod.status.podIP,
-          'properties' => properties.fetch(provider['job'], {}),
-          'bootstrap' => index.zero?
-        }
-      end
-    else
-      STDERR.puts "Resolving link #{key} via service #{provider}"
-      # Getting pods for a different service; since we have kube services, we don't handle it in configgin
-      svc = @client.get_service(provider['role'], @namespace)
-      pods = loop do
-        pods = @client.get_pods(namespace: @namespace, label_selector: "skiff-role-name=#{provider['role']}")
-        pods.reject! { |pod| pod.status.podIP.nil? }
-        pods.select! { |pod| pods.first.metadata.annotations['skiff-exported-properties'] }
-        break pods unless pods.empty?
-        sleep 1
-      end
-      properties = JSON.parse(pods.first.metadata.annotations['skiff-exported-properties'] || '{}')
-      @links[key]['instances'] = [
-        'name' => svc.metadata.name,
-        'index' => 0,
-        'id' => svc.metadata.name,
-        'az' => pods.first.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
-        'address' => svc.spec.clusterIP,
-        'properties' => properties.fetch(provider['job'], {}),
-        'bootstrap' => true
-      ]
-    end
-    @links[key]['properties'] = @links[key]['instances'].first['properties']
-    @links[key]
   end
 end
 

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -19,9 +19,15 @@ class KubeLinkSpecs
     @spec['job']['name']
   end
 
+  # pod_index returns a number for the given mod name. The number is expected to
+  # be unique across all pods for the role.
   def pod_index(name)
     index = name.rpartition('-').last
     return index.to_i if /^\d+$/ =~ index
+    # The pod name is something like role-abcxyz
+    # Derive the index from the randomness that went into the suffix.
+    # chars are the characters kubernetes might use to generate names
+    # Copied from https://github.com/kubernetes/kubernetes/blob/52a6ad0acb26/staging/src/k8s.io/client-go/pkg/util/rand/rand.go#L73
     chars = 'bcdfghjklmnpqrstvwxz0123456789'
     index.chars.map { |c| chars.index(c) }.reduce(0) { |v, c| v * chars.length + c }
   end

--- a/spec/cli/cli_spec.rb
+++ b/spec/cli/cli_spec.rb
@@ -32,5 +32,14 @@ describe Cli do
         Cli.check_opts(config)
       }.to raise_error(ArgMissingError, 'env2conf')
     end
+
+    it 'should exit when checking version' do
+      opts = {}
+      expect(Cli).to receive(:puts).with(Configgin::VERSION)
+      expect {
+        Cli.make_option_parser(opts).parse!(%w[--version --jobs /dev/null])
+      }.to raise_error(SystemExit)
+      expect(opts).to be_empty
+    end
   end
 end

--- a/spec/lib/environment_config_transmogrifier_spec.rb
+++ b/spec/lib/environment_config_transmogrifier_spec.rb
@@ -24,13 +24,11 @@ describe EnvironmentConfigTransmogrifier do
     end
 
     it 'should error on overriding non hash values' do
-      # Arrange
       environment_templates = {
         'properties.non_hash_key.error' => '((TEST_ENV_VAR))'
       }
+      expect(ENV).to receive(:to_hash).and_return('TEST_ENV_VAR' => 'false')
 
-      # Act
-      # Assert
       expect {
         EnvironmentConfigTransmogrifier.transmogrify(@base_config, environment_templates)
       }.to(raise_exception(NonHashValueOverride,

--- a/spec/lib/fixtures/fake.json
+++ b/spec/lib/fixtures/fake.json
@@ -1,10 +1,22 @@
 {
+  "job": {
+    "name": "fake"
+  },
   "properties": {
     "nats": {
       "machines": ["localhost", "127.0.0.1"]
     },
     "cloud_controller": {
       "base_dir": "directory"
+    },
+    "stuff": {
+      "one": 1,
+      "two": [ 2 ]
     }
-  }
+  },
+  "exported_properties": [
+    "nats.machines",
+    "stuff.one",
+    "stuff.two"
+  ]
 }

--- a/spec/lib/fixtures/fake.json
+++ b/spec/lib/fixtures/fake.json
@@ -18,5 +18,15 @@
     "nats.machines",
     "stuff.one",
     "stuff.two"
-  ]
+  ],
+  "consumes": {
+    "link_name": {
+      "role": "provider-role",
+      "job": "provider-job"
+    },
+    "self": {
+      "role": "fake",
+      "job": "unused"
+    }
+  }
 }

--- a/spec/lib/fixtures/fake.yml
+++ b/spec/lib/fixtures/fake.yml
@@ -4,3 +4,5 @@ nats_machines:
   - nats://127.0.0.1
 
 base_dir: directory
+self_address: fake.domain
+link_prop: ohai

--- a/spec/lib/fixtures/fake.yml.erb
+++ b/spec/lib/fixtures/fake.yml.erb
@@ -3,3 +3,5 @@ nats_machines:
 <% p("nats.machines").each do |address| %>  - nats://<%= address %>
 <% end %>
 base_dir: <%= p("cloud_controller.base_dir") %>
+self_address: <%= link("self").address %>
+link_prop: <%= link("link_name").p("hello.world") %>

--- a/spec/lib/fixtures/state.yml
+++ b/spec/lib/fixtures/state.yml
@@ -1,0 +1,28 @@
+# This is the Kubernetes state for job_spec.rb
+---
+pod:
+- metadata:
+    name: pod-0
+    namespace: namespace
+    annotations:
+      skiff-exported-properties: '{}'
+    labels:
+      skiff-role-name: fake
+  status:
+    podIP: '192.168.2.67'
+- metadata:
+    name: other-234z234
+    namespace: namespace
+    annotations:
+      skiff-exported-properties: '{"provider-job":{"hello":{"world":"ohai"}}}'
+    labels:
+      skiff-role-name: provider-role
+  status:
+    podIP: '192.168.2.39'
+
+service:
+- metadata:
+    name: provider-role
+    namespace: namespace
+  spec:
+    clusterIP: '192.168.2.221'

--- a/spec/lib/job_spec.rb
+++ b/spec/lib/job_spec.rb
@@ -1,17 +1,90 @@
 require 'spec_helper'
 require 'job'
+require 'ostruct'
 require 'stringio'
 require 'tempfile'
+require 'yaml'
+
+def fixture(relpath)
+  File.join(File.dirname(__FILE__), 'fixtures', relpath)
+end
+
+class MockKubeClient
+  def _get_single(type, name, namespace = nil)
+    items = (@state[type] || []).dup
+    items.select! { |i| i.metadata.name == name }
+    items.select! { |i| i.metadata.namespace == namespace } unless namespace.nil?
+    items.first
+  end
+
+  def _get_multiple(type, filters = {})
+    items = (@state[type] || []).dup
+    items.select! { |i| i.metadata.namespace == filters[:namespace] } unless filters[:namespace].nil?
+    unless filters[:label_selector].nil?
+      label, value = filters[:label_selector].split('=', 2)
+      items.select! { |i| i.metadata.labels[label] == value }
+    end
+    items
+  end
+
+  def method_missing(name, *args)
+    if name.to_s.start_with? 'get_'
+      type = name.to_s.sub(/^get_/, '').sub(/s$/, '')
+      return _get_multiple(type, *args) if name.to_s.end_with? 's'
+      return _get_single(type, *args)
+    end
+    super
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    return true if method_name.to_s.start_with? 'get_'
+    super
+  end
+
+  # _convert_ostruct takes an object and recursively converts any
+  # encountered hashes to an ostruct
+  def _convert_ostruct(obj)
+    return OpenStruct.new(Hash[obj.map { |k, v| [k, _convert_ostruct(v)] }]).freeze if obj.is_a?(Hash)
+    return obj.map { |v| _convert_ostruct(v) }.freeze if obj.is_a?(Array)
+    obj
+  end
+
+  def initialize(file_name)
+    @state = _convert_ostruct(YAML.load_file(file_name))
+  end
+end
 
 describe Job do
   context 'with some file paths and an eval context' do
-    template_filename = File.join(File.dirname(__FILE__), 'fixtures', 'fake.yml.erb')
-    restricted_template_filename = File.join(File.dirname(__FILE__), 'fixtures', '0600.yml.erb')
-    bosh_spec = File.join(File.dirname(__FILE__), 'fixtures', 'fake.json')
-    expect_filename = File.join(File.dirname(__FILE__), 'fixtures', 'fake.yml')
-    expect_output = File.read(expect_filename)
+    template_filename = fixture('fake.yml.erb')
+    restricted_template_filename = fixture('0600.yml.erb')
+    bosh_spec = JSON.parse(File.read(fixture('fake.json')))
+    expect_output = File.read(fixture('fake.yml'))
 
-    subject(:job) { Job.new(JSON.parse(File.read(bosh_spec)), 'namespace', nil) }
+    let(:client) { MockKubeClient.new(fixture('state.yml')) }
+    subject(:job) { Job.new(bosh_spec, 'namespace', client) }
+
+    before do
+      allow(ENV).to receive(:[]).and_wrap_original do |env, name|
+        case name
+        when 'KUBE_SERVICE_DOMAIN_SUFFIX' then 'domain'
+        else env.call(name)
+        end
+      end
+    end
+
+    around(:each) do |example|
+      # Eat stderr and only print it if something goes wrong
+      orig_stderr = $stderr
+      $stderr = StringIO.new('', 'w')
+      begin
+        result = example.run
+      ensure
+        orig_stderr.write $stderr.string if result.is_a?(Exception)
+        $stderr = orig_stderr
+      end
+      result
+    end
 
     it 'should preserve template permissions' do
       Dir.mktmpdir('configgin_mkdir_p_test') do |dir|

--- a/spec/lib/job_spec.rb
+++ b/spec/lib/job_spec.rb
@@ -67,10 +67,10 @@ describe Job do
     end
 
     it 'should list exported properties' do
-      expect(job.exported_properties).to eq({
+      expect(job.exported_properties).to eq(
         'nats' => { 'machines' => ['localhost', '127.0.0.1'] },
         'stuff' => { 'one' => 1, 'two' => [2] }
-      })
+      )
     end
   end
 end


### PR DESCRIPTION
This starts using BOSH links information generated by SUSE/fissile#283.

None of this code should trigger if there's no `link(…)` in the templates being evaluated.

Note that for use with SUSE/scf.git one of the etcd patches need to be updated to support this (reverting some of the changes in the local patch).