### PR TITLE
kube: determine bootstrapness via image version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    configgin (0.12.1)
+    configgin (0.13.0)
       bosh-template (~> 2.0)
       deep_merge (~> 1.1)
       kubeclient (~> 2.0)
@@ -29,7 +29,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (1.0.3)
     http_parser.rb (0.6.0)
-    kubeclient (2.4.0)
+    kubeclient (2.5.1)
       http (= 0.9.8)
       recursive-open-struct (= 1.0.0)
       rest-client

--- a/spec/lib/fixtures/state-multi.yml
+++ b/spec/lib/fixtures/state-multi.yml
@@ -1,0 +1,56 @@
+# This is the Kubernetes state for kube_link_generator_spec.rb
+---
+pod:
+- metadata:
+    uid: 893dd4a8-2067-44d3-aae7-1389f6a1789a
+    name: ready-pod-0
+    namespace: namespace
+    labels:
+      skiff-role-name: dummy
+    annotations:
+      skiff-exported-properties: '{}'
+  status:
+    containerStatuses:
+    - imageID: docker://aaa
+    - imageID: docker://bbb
+- metadata:
+    uid: fed899c8-0140-48fd-ac88-772368bde1f9
+    name: ready-pod-too-0
+    namespace: namespace
+    labels:
+      skiff-role-name: dummy
+    annotations:
+      skiff-exported-properties: '{}'
+  status:
+    containerStatuses:
+    - imageID: docker://aaa
+    - imageID: docker://bbb
+- metadata:
+    uid: 9091e7e7-ec89-453b-b5ca-352a47772fe9
+    name: bootstrap-pod-3
+    namespace: namespace
+    labels:
+      skiff-role-name: dummy
+    annotations:
+      skiff-exported-properties: '{}'
+  status:
+    containerStatuses:
+      - imageID: docker://ccc
+- metadata:
+    uid: 4d287101-9dba-4ae7-9447-3f3a3989badf
+    name: unrelated-pod-0
+    namespace: namespace
+    labels:
+      skiff-role-name: unrelated
+    annotations:
+      skiff-exported-properties: '{}'
+  status:
+    containerStatuses:
+    - imageID: docker://ccc
+
+service:
+- metadata:
+    name: provider-role
+    namespace: namespace
+  spec:
+    clusterIP: '192.168.2.221'

--- a/spec/lib/fixtures/state.yml
+++ b/spec/lib/fixtures/state.yml
@@ -10,6 +10,9 @@ pod:
       skiff-role-name: fake
   status:
     podIP: '192.168.2.67'
+    containerStatuses:
+    - imageID: docker://image-one
+    - imageID: docker://image-two
 - metadata:
     name: other-234z234
     namespace: namespace
@@ -19,6 +22,9 @@ pod:
       skiff-role-name: provider-role
   status:
     podIP: '192.168.2.39'
+    containerStatuses:
+    - imageID: docker://image-one
+    - imageID: docker://image-two
 
 service:
 - metadata:

--- a/spec/lib/job_spec.rb
+++ b/spec/lib/job_spec.rb
@@ -9,51 +9,6 @@ def fixture(relpath)
   File.join(File.dirname(__FILE__), 'fixtures', relpath)
 end
 
-class MockKubeClient
-  def _get_single(type, name, namespace = nil)
-    items = (@state[type] || []).dup
-    items.select! { |i| i.metadata.name == name }
-    items.select! { |i| i.metadata.namespace == namespace } unless namespace.nil?
-    items.first
-  end
-
-  def _get_multiple(type, filters = {})
-    items = (@state[type] || []).dup
-    items.select! { |i| i.metadata.namespace == filters[:namespace] } unless filters[:namespace].nil?
-    unless filters[:label_selector].nil?
-      label, value = filters[:label_selector].split('=', 2)
-      items.select! { |i| i.metadata.labels[label] == value }
-    end
-    items
-  end
-
-  def method_missing(name, *args)
-    if name.to_s.start_with? 'get_'
-      type = name.to_s.sub(/^get_/, '').sub(/s$/, '')
-      return _get_multiple(type, *args) if name.to_s.end_with? 's'
-      return _get_single(type, *args)
-    end
-    super
-  end
-
-  def respond_to_missing?(method_name, include_private = false)
-    return true if method_name.to_s.start_with? 'get_'
-    super
-  end
-
-  # _convert_ostruct takes an object and recursively converts any
-  # encountered hashes to an ostruct
-  def _convert_ostruct(obj)
-    return OpenStruct.new(Hash[obj.map { |k, v| [k, _convert_ostruct(v)] }]).freeze if obj.is_a?(Hash)
-    return obj.map { |v| _convert_ostruct(v) }.freeze if obj.is_a?(Array)
-    obj
-  end
-
-  def initialize(file_name)
-    @state = _convert_ostruct(YAML.load_file(file_name))
-  end
-end
-
 describe Job do
   context 'with some file paths and an eval context' do
     template_filename = fixture('fake.yml.erb')
@@ -73,18 +28,7 @@ describe Job do
       end
     end
 
-    around(:each) do |example|
-      # Eat stderr and only print it if something goes wrong
-      orig_stderr = $stderr
-      $stderr = StringIO.new('', 'w')
-      begin
-        result = example.run
-      ensure
-        orig_stderr.write $stderr.string if result.is_a?(Exception)
-        $stderr = orig_stderr
-      end
-      result
-    end
+    around(:each) { |ex| trap_error(ex) }
 
     it 'should preserve template permissions' do
       Dir.mktmpdir('configgin_mkdir_p_test') do |dir|

--- a/spec/lib/kube_link_generator_spec.rb
+++ b/spec/lib/kube_link_generator_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+require 'kube_link_generator'
+
+describe KubeLinkSpecs do
+  context 'with some file paths and an eval context' do
+    bosh_spec = JSON.parse(File.read(fixture('fake.json')))
+
+    let(:namespace) { 'namespace' }
+    let(:client) { MockKubeClient.new(fixture('state-multi.yml')) }
+    subject(:specs) { KubeLinkSpecs.new(bosh_spec, namespace, client) }
+
+    before do
+      allow(ENV).to receive(:[]).and_wrap_original do |env, name|
+        case name
+        when 'KUBE_SERVICE_DOMAIN_SUFFIX' then 'domain'
+        else env.call(name)
+        end
+      end
+    end
+
+    around(:each) { |ex| trap_error(ex) }
+
+    context :get_pod_instance_info do
+      it 'should return the expected information' do
+        job = 'dummy'
+        pods = specs._get_pods_for_role(job)
+        pod = pods.find { |p| p.metadata.name.start_with? 'bootstrap-pod' }
+        expect(pod).to_not be_nil
+        pods_per_image = specs.get_pods_per_image(pods)
+        expect(specs.get_pod_instance_info(pod, job, pods_per_image)).to include(
+          'address'    => nil,
+          'az'         => 'az0',
+          'bootstrap'  => true,
+          'id'         => 'bootstrap-pod-3',
+          'index'      => 3,
+          'name'       => 'bootstrap-pod-3',
+          'properties' => {}
+        )
+      end
+      it 'should not be bootstrap with multiple pods of the same images' do
+        job = 'dummy'
+        pods = specs._get_pods_for_role(job)
+        pod = pods.find { |p| p.metadata.name.start_with? 'ready-pod-0' }
+        expect(pod).to_not be_nil
+        pods_per_image = specs.get_pods_per_image(pods)
+        instance_info = specs.get_pod_instance_info(pod, job, pods_per_image)
+        expect(instance_info['bootstrap']).not_to be_truthy
+      end
+    end
+
+    context :get_pods_per_image do
+      it 'should return the expected counts' do
+        job = 'dummy'
+        pods = specs._get_pods_for_role(job)
+        pods_per_image = specs.get_pods_per_image(pods)
+        expect(pods_per_image).to eq(
+          '893dd4a8-2067-44d3-aae7-1389f6a1789a' => 2,
+          'fed899c8-0140-48fd-ac88-772368bde1f9' => 2,
+          '9091e7e7-ec89-453b-b5ca-352a47772fe9' => 1
+        )
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,60 @@
 require 'bundler/setup'
 Bundler.setup(:default, :test)
+
+class MockKubeClient
+  def _get_single(type, name, namespace = nil)
+    items = (@state[type] || []).dup
+    items.select! { |i| i.metadata.name == name }
+    items.select! { |i| i.metadata.namespace == namespace } unless namespace.nil?
+    items.first
+  end
+
+  def _get_multiple(type, filters = {})
+    items = (@state[type] || []).dup
+    items.select! { |i| i.metadata.namespace == filters[:namespace] } unless filters[:namespace].nil?
+    unless filters[:label_selector].nil?
+      label, value = filters[:label_selector].split('=', 2)
+      items.select! { |i| i.metadata.labels[label] == value }
+    end
+    items
+  end
+
+  def method_missing(name, *args)
+    if name.to_s.start_with? 'get_'
+      type = name.to_s.sub(/^get_/, '').sub(/s$/, '')
+      return _get_multiple(type, *args) if name.to_s.end_with? 's'
+      return _get_single(type, *args)
+    end
+    super
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    return true if method_name.to_s.start_with? 'get_'
+    super
+  end
+
+  # _convert_ostruct takes an object and recursively converts any
+  # encountered hashes to an ostruct
+  def _convert_ostruct(obj)
+    return OpenStruct.new(Hash[obj.map { |k, v| [k, _convert_ostruct(v)] }]).freeze if obj.is_a?(Hash)
+    return obj.map { |v| _convert_ostruct(v) }.freeze if obj.is_a?(Array)
+    obj
+  end
+
+  def initialize(file_name)
+    @state = _convert_ostruct(YAML.load_file(file_name))
+  end
+end
+
+def trap_error(example)
+  # Eat stderr and only print it if something goes wrong
+  orig_stderr = $stderr
+  $stderr = StringIO.new('', 'w')
+  begin
+    result = example.run
+  ensure
+    orig_stderr.write $stderr.string if result.is_a?(Exception)
+    $stderr = orig_stderr
+  end
+  result
+end


### PR DESCRIPTION
Instead of configuring all nodes of index 0 as bootstrap node, instead set a pod as bootstrap if there are no other pods with the same version. This makes it easier to deal with upgrades in a kube environment (where
the last pod - not necessarily index 0 - will be upgraded first). 

This also means that we can configure some of the roles to no longer be indexed (because they only needed it for bootstrapping).

Reminder: the easiest way to test this is to have a SCF vagrant box up, then run [`update-stemcell.sh`](https://github.com/SUSE/configgin/blob/master/update-stemcell.sh) to build new images on there. Maybe set `FISSILE_DOCKER_ORGANIZATION` to your personal account and push those up to docker hub to deploy on CaaSP too.