### PR TITLE
kube: update spec.id / spec.deployment

### DIFF
--- a/lib/job.rb
+++ b/lib/job.rb
@@ -8,7 +8,13 @@ class Job
     @spec = spec
     @namespace = namespace
     @client = client
+    @spec['id'] = this_pod.metadata.uid
+    @spec['deployment'] = this_pod.metadata.namespace
     @spec['links'] = KubeLinkSpecs.new(@spec, @namespace, @client, client_stateful_set)
+  end
+
+  def this_pod
+    @this_pod ||= @client.get_pod(ENV['HOSTNAME'], @namespace)
   end
 
   attr_reader :spec

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -66,7 +66,8 @@ class KubeLinkSpecs
     {
       'name' => pod.metadata.name,
       'index' => index,
-      'id' => pod.metadata.name,
+      'id' => pod.metadata.uid,
+      'deployment' => pod.metadata.namespace,
       'az' => pod.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
       'address' => pod.status.podIP,
       'properties' => properties.fetch(job, {}),
@@ -97,7 +98,8 @@ class KubeLinkSpecs
     {
       'name' => svc.metadata.name,
       'index' => 0, # Completely made up index; there is only ever one service
-      'id' => svc.metadata.name,
+      'id' => svc.metadata.uid,
+      'deployment' => svc.metadata.namespace,
       'az' => pod.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
       'address' => svc.spec.clusterIP,
       'properties' => properties.fetch(job, {}),
@@ -114,7 +116,8 @@ class KubeLinkSpecs
       {
         'name' => ss.metadata.name,
         'index' => i,
-        'id' => ss.metadata.name,
+        'id' => ss.metadata.uid,
+        'deployment' => ss.metadata.namespace,
         'az' => pod.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
         'address' => "#{ss.metadata.name}-#{i}.#{ss.spec.serviceName}",
         'properties' => properties.fetch(job, {}),

--- a/spec/lib/job_spec.rb
+++ b/spec/lib/job_spec.rb
@@ -23,6 +23,7 @@ describe Job do
       allow(ENV).to receive(:[]).and_wrap_original do |env, name|
         case name
         when 'KUBE_SERVICE_DOMAIN_SUFFIX' then 'domain'
+        when 'HOSTNAME' then 'pod-0'
         else env.call(name)
         end
       end

--- a/spec/lib/kube_link_generator_spec.rb
+++ b/spec/lib/kube_link_generator_spec.rb
@@ -48,7 +48,8 @@ describe KubeLinkSpecs do
           'address'    => '1.2.3.4',
           'az'         => 'az0',
           'bootstrap'  => true,
-          'id'         => 'bootstrap-pod-3',
+          'id'         => '9091e7e7-ec89-453b-b5ca-352a47772fe9',
+          'deployment' => 'namespace',
           'index'      => 3,
           'name'       => 'bootstrap-pod-3',
           'properties' => {}


### PR DESCRIPTION
BOSH (specifically, consul release) expects spec.uid to be a GUID. Also, it expects a `spec.deployment`; here we are using the namespace, though ideally it would be the helm deployment name.