### PR TITLE
Fix bootstrap determination on rolling upgrade

### DIFF
--- a/lib/environment_config_transmogrifier.rb
+++ b/lib/environment_config_transmogrifier.rb
@@ -46,8 +46,6 @@ module EnvironmentConfigTransmogrifier
       inject_value(base_config, key.split('.'), value, key)
     end
 
-    base_config['bootstrap'] = (base_config['index'] || 0).zero?
-
     base_config
   end
 

--- a/lib/job.rb
+++ b/lib/job.rb
@@ -11,7 +11,7 @@ class Job
     links = @spec['links'] = KubeLinkSpecs.new(@spec, @namespace, @client, client_stateful_set)
 
     # Figure out whether _this_ should bootstrap
-    pods = links.get_pods_for_role(self_role, true)
+    pods = @client.get_pods(namespace: @namespace, label_selector: "skiff-role-name=#{self_role}")
     pods_per_image = links.get_pods_per_image(pods)
     @spec['bootstrap'] = pods_per_image[self_pod.metadata.uid] < 2
   end

--- a/lib/job.rb
+++ b/lib/job.rb
@@ -13,7 +13,6 @@ class Job
     # Figure out whether _this_ should bootstrap
     pods = links.get_pods_for_role(self_role, true)
     pods_per_image = links.get_pods_per_image(pods)
-    pod_info = links.get_pod_instance_info(self_pod, nil, pods_per_image)
     @spec['bootstrap'] = pods_per_image[self_pod.metadata.uid] < 2
   end
 

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -137,8 +137,7 @@ class KubeLinkSpecs
     provider = @spec['consumes'][key]
     unless provider
       $stderr.puts "No link provider found for #{key}"
-      @links[key] = nil
-      return @links[key]
+      return @links[key] = nil
     end
 
     if provider['role'] == this_name

--- a/spec/lib/environment_config_transmogrifier_spec.rb
+++ b/spec/lib/environment_config_transmogrifier_spec.rb
@@ -47,41 +47,11 @@ describe EnvironmentConfigTransmogrifier do
       expect(new_config['properties']['nil_value']).to eq 'hello'
     end
 
-    it 'should inject bootstrap without index' do
-      # Arrange
+    it 'should not inject bootstrap' do
+      # Bootstrap stuff moved to the job
       environment_templates = {}
-
-      # Act
       new_config = EnvironmentConfigTransmogrifier.transmogrify(@base_config, environment_templates)
-
-      # Assert
-      expect(new_config['bootstrap']).to be true
-    end
-
-    it 'should inject bootstrap for index of primary component' do
-      # Arrange
-      environment_templates = {
-        'index' => 0
-      }
-
-      # Act
-      new_config = EnvironmentConfigTransmogrifier.transmogrify(@base_config, environment_templates)
-
-      # Assert
-      expect(new_config['bootstrap']).to be true
-    end
-
-    it 'should inject bootstrap for index of non-primary component' do
-      # Arrange
-      environment_templates = {
-        'index' => 1
-      }
-
-      # Act
-      new_config = EnvironmentConfigTransmogrifier.transmogrify(@base_config, environment_templates)
-
-      # Assert
-      expect(new_config['bootstrap']).to be false
+      expect(new_config).not_to include('bootstrap')
     end
 
     it 'should inject a configuration value' do

--- a/spec/lib/job_spec.rb
+++ b/spec/lib/job_spec.rb
@@ -102,7 +102,7 @@ describe Job do
 
     it 'should bootstrap when pod is alone' do
       allow(ENV).to receive(:[]).and_wrap_original do |env, name|
-        (name == 'HOSTNAME') ? 'unrelated-pod-0' : env.call(name)
+        name == 'HOSTNAME' ? 'unrelated-pod-0' : env.call(name)
       end
       job = Job.new(bosh_spec, namespace, client, client)
       expect(job.spec['bootstrap']).to be_truthy
@@ -110,7 +110,7 @@ describe Job do
 
     it 'should bootstrap when only pod with this image' do
       allow(ENV).to receive(:[]).and_wrap_original do |env, name|
-        (name == 'HOSTNAME') ? 'bootstrap-pod-3' : env.call(name)
+        name == 'HOSTNAME' ? 'bootstrap-pod-3' : env.call(name)
       end
       job = Job.new(bosh_spec, namespace, client, client)
       expect(job.spec['bootstrap']).to be_truthy
@@ -118,7 +118,7 @@ describe Job do
 
     it 'shoud not upgrade when multiple pods with same image' do
       allow(ENV).to receive(:[]).and_wrap_original do |env, name|
-        (name == 'HOSTNAME') ? 'ready-pod-0' : env.call(name)
+        name == 'HOSTNAME' ? 'ready-pod-0' : env.call(name)
       end
       job = Job.new(bosh_spec, namespace, client, client)
       expect(job.spec['bootstrap']).to be_falsy

--- a/spec/lib/job_spec.rb
+++ b/spec/lib/job_spec.rb
@@ -22,6 +22,7 @@ describe Job do
     before do
       allow(ENV).to receive(:[]).and_wrap_original do |env, name|
         case name
+        when 'HOSTNAME' then 'pod-0'
         when 'KUBE_SERVICE_DOMAIN_SUFFIX' then 'domain'
         else env.call(name)
         end
@@ -88,6 +89,39 @@ describe Job do
         'nats' => { 'machines' => ['localhost', '127.0.0.1'] },
         'stuff' => { 'one' => 1, 'two' => [2] }
       )
+    end
+  end
+
+  context 'when resolving bootstrapness' do
+    bosh_spec = JSON.parse(File.read(fixture('fake.json')))
+
+    let(:namespace) { 'namespace' }
+    let(:client) { MockKubeClient.new(fixture('state-multi.yml')) }
+
+    around(:each) { |ex| trap_error(ex) }
+
+    it 'should bootstrap when pod is alone' do
+      allow(ENV).to receive(:[]).and_wrap_original do |env, name|
+        (name == 'HOSTNAME') ? 'unrelated-pod-0' : env.call(name)
+      end
+      job = Job.new(bosh_spec, namespace, client, client)
+      expect(job.spec['bootstrap']).to be_truthy
+    end
+
+    it 'should bootstrap when only pod with this image' do
+      allow(ENV).to receive(:[]).and_wrap_original do |env, name|
+        (name == 'HOSTNAME') ? 'bootstrap-pod-3' : env.call(name)
+      end
+      job = Job.new(bosh_spec, namespace, client, client)
+      expect(job.spec['bootstrap']).to be_truthy
+    end
+
+    it 'shoud not upgrade when multiple pods with same image' do
+      allow(ENV).to receive(:[]).and_wrap_original do |env, name|
+        (name == 'HOSTNAME') ? 'ready-pod-0' : env.call(name)
+      end
+      job = Job.new(bosh_spec, namespace, client, client)
+      expect(job.spec['bootstrap']).to be_falsy
     end
   end
 end


### PR DESCRIPTION
We previously determined `spec.bootstrap` for _this_ pod (instead of the links) based on whether the index was zero. That isn't nearly good enough when we do rolling upgrades, as helm starts from the highest index instead.  Port the logic (which we already had, in the wrong place) over instead.