### PR TITLE
Enable ERB trim mode

### DIFF
--- a/lib/job.rb
+++ b/lib/job.rb
@@ -58,7 +58,7 @@ class Job
     # Read the erb template
     begin
       perms = File.stat(input_file_path).mode
-      erb_template = ERB.new(File.read(input_file_path))
+      erb_template = ERB.new(File.read(input_file_path), safe_level = nil, trim_mode = "-")
       erb_template.filename = input_file_path
     rescue Errno::ENOENT
       raise "failed to read template file #{input_file_path}"


### PR DESCRIPTION
Like BOSH, `configgin` should also support the ERB trim mode so that ERB
templates that use `<% somthing -%>` are properly processed, for example:
[cloudfoundry/garden-runc-release garden_start.erb](https://github.com/cloudfoundry/garden-runc-release/blob/1a58f47a5afa9566338b23fdcff0f15536e5faab/jobs/garden/templates/bin/garden_start.erb)

The trim mode options are inspired by the [renderer.rb of BOSH](https://github.com/cloudfoundry/bosh/blob/master/src/bosh-template/lib/bosh/template/renderer.rb).
