### PR TITLE
Adding support for multiple metadata skiff-annotations per container

### DIFF
--- a/bin/configgin
+++ b/bin/configgin
@@ -65,12 +65,13 @@ job_configs.each do |job, job_config|
   jobs[job] = Job.new(bosh_spec, kube_namespace, kube_client, kube_client_stateful_set)
 end
 
-exported_properties = Hash[jobs.map { |name, job| [name, job.exported_properties] }]
-kube_client.patch_pod(
-  ENV['HOSTNAME'],
-  { metadata: { annotations: { :'skiff-exported-properties' => exported_properties.to_json } } },
-  kube_namespace
-)
+jobs.each do |name, job|
+  kube_client.patch_pod(
+    ENV['HOSTNAME'],
+    { metadata: { annotations: { :"skiff-exported-properties-#{name}" => job.exported_properties.to_json } } },
+    kube_namespace
+  )
+end
 
 jobs.each do |job_name, job|
   dns_encoder = KubeDNSEncoder.new(job.spec['links'])

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -37,7 +37,7 @@ class KubeLinkSpecs
     @client.get_pods(namespace: @namespace, label_selector: "skiff-role-name=#{role_name}")
   end
 
-  def get_pods_for_role(role_name, wait_for_ip)
+  def get_pods_for_role(role_name, wait_for_ip, job)
     loop do
       # The 30.times loop exists to print out status messages
       30.times do
@@ -46,30 +46,34 @@ class KubeLinkSpecs
           if wait_for_ip
             # Wait until all pods have IP addresses and properties
             break unless pods.all? { |pod| pod.status.podIP }
-            break unless pods.all? { |pod| pod.metadata.annotations['skiff-exported-properties'] }
+            break unless pods.all? { |pod| pod.metadata.annotations["skiff-exported-properties-#{job}"] }
           else
             # We just need one pod with exported properties
             pods.select! { |pod| pod.status.podIP }
-            pods.select! { |pod| pod.metadata.annotations['skiff-exported-properties'] }
+            pods.select! { |pod| pod.metadata.annotations["skiff-exported-properties-#{job}"] }
           end
           return pods unless pods.empty?
         end
         sleep 1
       end
-      $stdout.puts "Waiting for pods for role #{role_name} (at #{Time.now})..."
+      $stdout.puts "Waiting for pods for role #{role_name} and provider job #{job} (at #{Time.now})..."
     end
+  end
+
+  def get_exported_properties(pod, job)
+    exported_properties = pod.metadata.annotations["skiff-exported-properties-#{job}"]
+    exported_properties.nil? ? {} : JSON.parse(exported_properties)
   end
 
   def get_pod_instance_info(pod, job, pods_per_image)
     index = pod_index(pod.metadata.name)
-    properties = JSON.parse(pod.metadata.annotations['skiff-exported-properties'])
     {
       'name' => pod.metadata.name,
       'index' => index,
       'id' => pod.metadata.name,
       'az' => pod.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
       'address' => pod.status.podIP,
-      'properties' => properties.fetch(job, {}),
+      'properties' => get_exported_properties(pod, job),
       'bootstrap' => pods_per_image[pod.metadata.uid] < 2
     }
   end
@@ -92,23 +96,21 @@ class KubeLinkSpecs
 
   def get_svc_instance_info(role_name, job)
     svc = @client.get_service(role_name, @namespace)
-    pod = get_pods_for_role(role_name, false).first
-    properties = JSON.parse(pod.metadata.annotations['skiff-exported-properties'])
+    pod = get_pods_for_role(role_name, false, job).first
     {
       'name' => svc.metadata.name,
       'index' => 0, # Completely made up index; there is only ever one service
       'id' => svc.metadata.name,
       'az' => pod.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
       'address' => svc.spec.clusterIP,
-      'properties' => properties.fetch(job, {}),
+      'properties' => get_exported_properties(pod, job),
       'bootstrap' => true
     }
   end
 
   def get_statefulset_instance_info(role_name, job)
     ss = @client_stateful_set.get_stateful_set(role_name, @namespace)
-    pod = get_pods_for_role(role_name, false).first
-    properties = JSON.parse(pod.metadata.annotations['skiff-exported-properties'])
+    pod = get_pods_for_role(role_name, false, job).first
 
     Array.new(ss.spec.replicas) do |i|
       {
@@ -117,7 +119,7 @@ class KubeLinkSpecs
         'id' => ss.metadata.name,
         'az' => pod.metadata.annotations['failure-domain.beta.kubernetes.io/zone'] || 'az0',
         'address' => "#{ss.metadata.name}-#{i}.#{ss.spec.serviceName}",
-        'properties' => properties.fetch(job, {}),
+        'properties' => get_exported_properties(pod, job),
         'bootstrap' => i.zero?
       }
     end
@@ -142,7 +144,7 @@ class KubeLinkSpecs
 
     if provider['role'] == this_name
       $stderr.puts "Resolving link #{key} via self provider #{provider}"
-      pods = get_pods_for_role(provider['role'], true)
+      pods = get_pods_for_role(provider['role'], true, provider['job'])
       pods_per_image = get_pods_per_image(pods)
       instances = pods.map { |p| get_pod_instance_info(p, provider['job'], pods_per_image) }
     elsif service? provider['role']

--- a/spec/lib/fixtures/state-multi.yml
+++ b/spec/lib/fixtures/state-multi.yml
@@ -8,7 +8,7 @@ pod:
     labels:
       skiff-role-name: dummy
     annotations:
-      skiff-exported-properties: '{}'
+      skiff-exported-properties-dummy: '{}'
   status:
     podIP: 1.2.3.4
     containerStatuses:
@@ -21,7 +21,7 @@ pod:
     labels:
       skiff-role-name: dummy
     annotations:
-      skiff-exported-properties: '{}'
+      skiff-exported-properties-dummy: '{}'
   status:
     podIP: 1.2.3.4
     containerStatuses:
@@ -34,7 +34,7 @@ pod:
     labels:
       skiff-role-name: dummy
     annotations:
-      skiff-exported-properties: '{}'
+      skiff-exported-properties-dummy: '{}'
   status:
     podIP: 1.2.3.4
     containerStatuses:
@@ -46,7 +46,7 @@ pod:
     labels:
       skiff-role-name: unrelated
     annotations:
-      skiff-exported-properties: '{}'
+      skiff-exported-properties-dummy: '{}'
   status:
     podIP: 1.2.3.4
     containerStatuses:

--- a/spec/lib/fixtures/state.yml
+++ b/spec/lib/fixtures/state.yml
@@ -5,7 +5,7 @@ pod:
     name: pod-0
     namespace: namespace
     annotations:
-      skiff-exported-properties: '{}'
+      skiff-exported-properties-unused: '{}'
     labels:
       skiff-role-name: fake
   status:
@@ -17,7 +17,7 @@ pod:
     name: other-234z234
     namespace: namespace
     annotations:
-      skiff-exported-properties: '{"provider-job":{"hello":{"world":"ohai"}}}'
+      skiff-exported-properties-provider-job: '{"hello":{"world":"ohai"}}'
     labels:
       skiff-role-name: provider-role
   status:


### PR DESCRIPTION
- Modify configgin to generate one `skiff-exported-properties-<job>` entry
  per provider job.
- Modify `kube_link_generator.rb` to consume specific provide job annotation.
- Refactor test cases to support new annotations syntax.

This is originated from issue #72 

@mook-as @alexjh @viovanov @zhanggbj fyi, opinions on this PR? 

Signed-off-by: Matthias Diester <matthias.diester@de.ibm.com>