### PR TITLE
When bootstrapping a pod, check that:

### DIFF
--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -84,9 +84,11 @@ class KubeLinkSpecs
     sets = Hash.new(0)
     keys = {}
     pods.each do |pod|
-      key = pod.status.containerStatuses.map(&:imageID).sort.join("\n")
-      sets[key] += 1
-      keys[pod.metadata.uid] = key
+      unless pod.status.containerStatuses.nil?
+        key = pod.status.containerStatuses.map(&:imageID).sort.join("\n")
+        sets[key] += 1
+        keys[pod.metadata.uid] = key
+      end
     end
     pods.each do |pod|
       result[pod.metadata.uid] = sets[keys[pod.metadata.uid]]

--- a/spec/lib/fixtures/state-multi.yml
+++ b/spec/lib/fixtures/state-multi.yml
@@ -51,6 +51,17 @@ pod:
     podIP: 1.2.3.4
     containerStatuses:
     - imageID: docker://ccc
+- metadata:
+    uid: 650aa4a8-2034-55c1-gge9-2451d6a2799b
+    name: pending-pod-0
+    namespace: namespace
+    labels:
+      skiff-role-name: pending
+    annotations:
+      skiff-exported-properties-dummy: '{}'
+  status:
+    podIP: 1.2.3.4
+    containerStatuses:
 
 service:
 - metadata:

--- a/spec/lib/fixtures/state-multi.yml
+++ b/spec/lib/fixtures/state-multi.yml
@@ -61,7 +61,7 @@ pod:
       skiff-exported-properties-dummy: '{}'
   status:
     podIP: 1.2.3.4
-    containerStatuses:
+    containerStatuses: ~ # Simulate pending pod
 
 service:
 - metadata:

--- a/spec/lib/job_spec.rb
+++ b/spec/lib/job_spec.rb
@@ -109,6 +109,14 @@ describe Job do
       expect(job.spec['bootstrap']).to be_truthy
     end
 
+    it 'should not break bootstrapping a pod in pending status' do
+      allow(ENV).to receive(:[]).and_wrap_original do |env, name|
+        name == 'HOSTNAME' ? 'pending-pod-0' : env.call(name)
+      end
+      job = Job.new(bosh_spec, namespace, client, client)
+      expect(job.spec['containerStatuses']).to be_falsey
+    end
+
     it 'should bootstrap when only pod with this image' do
       allow(ENV).to receive(:[]).and_wrap_original do |env, name|
         name == 'HOSTNAME' ? 'bootstrap-pod-3' : env.call(name)


### PR DESCRIPTION
- During pods per image metadata retrieval, containerStatuses is not nil.
- Add test case for this scenario

A nil containerStatuses key, will happen when the pod is
in PENDING status.