### PR TITLE
When bootstrapping a pod, check that(NEW CONFIGGIN 0.15.2 required):

### DIFF
--- a/lib/configgin/version.rb
+++ b/lib/configgin/version.rb
@@ -1,3 +1,3 @@
 module Configgin
-  VERSION = '0.15.1'.freeze
+  VERSION = '0.15.2'.freeze
 end

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -84,9 +84,11 @@ class KubeLinkSpecs
     sets = Hash.new(0)
     keys = {}
     pods.each do |pod|
-      key = pod.status.containerStatuses.map(&:imageID).sort.join("\n")
-      sets[key] += 1
-      keys[pod.metadata.uid] = key
+      unless pod.status.containerStatuses.nil?
+        key = pod.status.containerStatuses.map(&:imageID).sort.join("\n")
+        sets[key] += 1
+        keys[pod.metadata.uid] = key
+      end
     end
     pods.each do |pod|
       result[pod.metadata.uid] = sets[keys[pod.metadata.uid]]

--- a/spec/lib/fixtures/state-multi.yml
+++ b/spec/lib/fixtures/state-multi.yml
@@ -51,6 +51,17 @@ pod:
     podIP: 1.2.3.4
     containerStatuses:
     - imageID: docker://ccc
+- metadata:
+    uid: 650aa4a8-2034-55c1-gge9-2451d6a2799b
+    name: pending-pod-0
+    namespace: namespace
+    labels:
+      skiff-role-name: pending
+    annotations:
+      skiff-exported-properties-dummy: '{}'
+  status:
+    podIP: 1.2.3.4
+    containerStatuses:
 
 service:
 - metadata:

--- a/spec/lib/fixtures/state-multi.yml
+++ b/spec/lib/fixtures/state-multi.yml
@@ -61,7 +61,7 @@ pod:
       skiff-exported-properties-dummy: '{}'
   status:
     podIP: 1.2.3.4
-    containerStatuses:
+    containerStatuses: ~ # Simulate pending pod
 
 service:
 - metadata:

--- a/spec/lib/job_spec.rb
+++ b/spec/lib/job_spec.rb
@@ -108,6 +108,14 @@ describe Job do
       expect(job.spec['bootstrap']).to be_truthy
     end
 
+    it 'should not break bootstrapping a pod in pending status' do
+      allow(ENV).to receive(:[]).and_wrap_original do |env, name|
+        name == 'HOSTNAME' ? 'pending-pod-0' : env.call(name)
+      end
+      job = Job.new(bosh_spec, namespace, client, client)
+      expect(job.spec['containerStatuses']).to be_falsey
+    end
+
     it 'should bootstrap when only pod with this image' do
       allow(ENV).to receive(:[]).and_wrap_original do |env, name|
         name == 'HOSTNAME' ? 'bootstrap-pod-3' : env.call(name)


### PR DESCRIPTION

Cherry-picking commit e5d7cacb249453361e871daa601a68ed90ccdf6e and commit f2b221c5a594e211bf2cc3a95cee32a2a905a544 on top of v0.15 branch, to include code merged in PR #78 .

Also, adding an extra commit to explicitly bump configging from version `0.15.1` to `0.15.2`. Reason behind, is that v0.16 includes a dependency on an SCF version we are not using yet.
